### PR TITLE
Cancel button

### DIFF
--- a/app/controllers/infections_controller.rb
+++ b/app/controllers/infections_controller.rb
@@ -20,9 +20,9 @@ class InfectionsController < ApplicationController
     authorize @infection
   end
 
-  def update
+  def cancel
     @infection = Infection.find(params[:id])
-    @infection.update(infection_params)
+    @infection.status = "cancelled"
     redirect_to organisms_path # this can later be changed so that the redirect
     # leads to the dashboard or something
     authorize @infection

--- a/app/controllers/infections_controller.rb
+++ b/app/controllers/infections_controller.rb
@@ -14,12 +14,6 @@ class InfectionsController < ApplicationController
     redirect_to organism_path(@organism)
   end
 
-  # def edit
-  #   @infection = Infection.find(params[:id])
-  #   @organism = Organism.find(params[:organism_id])
-  #   authorize @infection
-  # end
-
   def cancel
     @infection = Infection.find(params[:id])
     @infection.status = "cancelled"

--- a/app/controllers/infections_controller.rb
+++ b/app/controllers/infections_controller.rb
@@ -14,16 +14,17 @@ class InfectionsController < ApplicationController
     redirect_to organism_path(@organism)
   end
 
-  def edit
-    @infection = Infection.find(params[:id])
-    @organism = Organism.find(params[:organism_id])
-    authorize @infection
-  end
+  # def edit
+  #   @infection = Infection.find(params[:id])
+  #   @organism = Organism.find(params[:organism_id])
+  #   authorize @infection
+  # end
 
   def cancel
     @infection = Infection.find(params[:id])
     @infection.status = "cancelled"
-    redirect_to organisms_path # this can later be changed so that the redirect
+    @infection.save
+    redirect_to infections_path # this can later be changed so that the redirect
     # leads to the dashboard or something
     authorize @infection
   end

--- a/app/policies/infection_policy.rb
+++ b/app/policies/infection_policy.rb
@@ -9,7 +9,7 @@ class InfectionPolicy < ApplicationPolicy
     true
   end
 
-  def update?
+  def cancel?
     record.user == user
   end
 end

--- a/app/views/infections/index.html.erb
+++ b/app/views/infections/index.html.erb
@@ -8,5 +8,6 @@
       <li> species: <%= infection.organism.species %></li>
     </ul>
   <p>infection period: <%= infection.infection_start %> - <%= infection.infection_end %></p>
+  <%= link_to "Cancel Infection", "cancel_infection" %>
   </div>
 <% end %>

--- a/app/views/infections/index.html.erb
+++ b/app/views/infections/index.html.erb
@@ -8,6 +8,6 @@
       <li> species: <%= infection.organism.species %></li>
     </ul>
   <p>infection period: <%= infection.infection_start %> - <%= infection.infection_end %></p>
-  <%= link_to "Cancel Infection", "cancel_infection" %>
+  <%= link_to "Cancel Infection", cancel_infection_path(infection), method: :patch %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,10 @@ Rails.application.routes.draw do
   root to: 'pages#home'
 
   resources :organisms, only: [:index, :show] do
-    resources :infections, only: [:new, :create, :edit, :update]
+    resources :infections, only: [:new, :create]
   end
 
   resources :infections, only: [:index]
+  patch '/infections/:id', to: 'infections#cancel', as: :cancel_infection
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
I changed the routes by removing the edit and update actions from infections and adding a cancel action. The cancel action changes the status to cancelled and then redirects to the /infections page.
I added a "cancel" link to the infections-page. That link calls the cancel_infection URL with the "patch" method.

![Bildschirmfoto 2021-01-30 um 14 12 10](https://user-images.githubusercontent.com/17951950/106357235-2fa10480-6305-11eb-9a8b-cd08b673c554.png)
